### PR TITLE
fix: 修复查询自制谱时某些id导致的后端undefined访问错误(如192650)

### DIFF
--- a/backend/src/view/songChart.ts
+++ b/backend/src/view/songChart.ts
@@ -30,7 +30,7 @@ export async function drawSongChart(songId: number, difficultyId: number, displa
         diff: difficultyName[difficultyId],
         cover: song.getSongJacketImageURL(displayedServerList)
     }, songChart as any)
-    
+
     let buffer:Buffer
     if( compress!=undefined && compress){
         buffer = await tempcanv.toBuffer('jpeg',{quality:0.7})
@@ -44,10 +44,10 @@ export async function drawSongChart(songId: number, difficultyId: number, displa
 
 export async function drawCommunitySongChart(songId: number, compress: boolean): Promise<Array<Buffer | string>> {
     const res:any = await callAPIAndCacheResponse(`${Bestdoriurl}/api/post/details?id=${songId}`)
-    if (res.result == 'false') {
+    if (!res?.result || res.result == 'false') {
         return ['获取谱面信息失败']
     }
-    if (res.post.categoryId != 'chart') {
+    if (res.post?.categoryId != 'chart') {
         return [`id${songId}对应的帖子不是谱面，请检查是否输入错误`]
     }
     const cover = res.post.song.type == 'bandori' ? (new Song(res.post.song.id)).getSongJacketImageURL() : res.post.song.cover
@@ -57,7 +57,7 @@ export async function drawCommunitySongChart(songId: number, compress: boolean):
         ...res.post,
         cover
     }, res.post.chart as any)
-    
+
     let buffer:Buffer
     if( compress!=undefined && compress){
         buffer = await tempcanv.toBuffer('jpeg',{quality:0.7})


### PR DESCRIPTION
修bug：查询自制谱谱面如192650时
由于res为```{ result: false, code: 'REQUEST_INVALID' }```
导致执行如下代码时无法进入第一个分支
```
if (res.result == 'false') {
        return ['获取谱面信息失败']
    }

    if (res.post.categoryId != 'chart') {
        return [`id${songId}对应的帖子不是谱面，请检查是否输入错误`]
    }
```
从而在第二个分支报错
```
TypeError: Cannot read properties of undefined (reading 'categoryId')
    at drawCommunitySongChart (E:\MyKoishiCode\tsugu-bot\external\tsugu-bangdream-bot\backend\src\view\songChart.ts:51:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async <anonymous> (E:\MyKoishiCode\tsugu-bot\external\tsugu-bangdream-bot\backend\src\routers\songChart.ts:52:28)
[15:05:46] [Response] ::ffff:127.0.0.1 /songChart/community 0.00MB 250ms
```
